### PR TITLE
Remove rel2, replace rel2 with rel

### DIFF
--- a/Generator/Sources/Generator/Definitions.swift
+++ b/Generator/Sources/Generator/Definitions.swift
@@ -622,11 +622,6 @@ extension Attribute {
         description: "Relationship between the location in the document containing the hyperlink and the destination resource."
     )
 
-    static let rel2 = Attribute(
-        name: "rel2",
-        description: "Relationship between the document containing the hyperlink and the destination resource."
-    )
-
     static let `required` = Attribute(
         name: "required",
         description: "Whether the control is required for form submission.",

--- a/Sources/HTML/Tags.swift
+++ b/Sources/HTML/Tags.swift
@@ -6010,7 +6010,7 @@ public func li(
 ///      - media: Applicable media.
 ///      - nonce: Cryptographic nonce used in Content Security Policy checks [CSP].
 ///      - referrerpolicy: Referrer policy for fetches initiated by the element.
-///      - rel2: Relationship between the document containing the hyperlink and the destination resource.
+///      - rel: Relationship between the document containing the hyperlink and the destination resource.
 ///      - role: ARIA semantic role.
 ///      - sizes: Sizes of the icons (for `icon`).
 ///      - slot: The element's desired slot.
@@ -6050,7 +6050,7 @@ public func link(
     media: String? = nil,
     nonce: String? = nil,
     referrerpolicy: String? = nil,
-    rel2: String? = nil,
+    rel: String? = nil,
     role: String? = nil,
     sizes: String? = nil,
     slot: String? = nil,
@@ -6092,7 +6092,7 @@ public func link(
     attributes["media"] = media
     attributes["nonce"] = nonce
     attributes["referrerpolicy"] = referrerpolicy
-    attributes["rel2"] = rel2
+    attributes["rel"] = rel
     attributes["role"] = role
     attributes["sizes"] = sizes
     attributes["slot"] = slot


### PR DESCRIPTION
I'm not sure what `rel2` is supposed to be? But it was impossible to include a stylesheet (`<link rel="stylesheet" href="/style.css" />`) so I changed it to `rel`, as expected.