### PR TITLE
Added raw nodes and escaped text nodes.

### DIFF
--- a/Sources/Swim/Node.swift
+++ b/Sources/Swim/Node.swift
@@ -6,6 +6,9 @@ public enum Node: Hashable {
 
     // The `Node`'s text contents.
     case text(String)
+    
+    // Raw HTML that gets rendered without processing.
+    case raw(String)
 
     // The `Node`'s text contents.
     case comment(String)
@@ -78,6 +81,13 @@ extension Node: TextOutputStreamable {
                 target.write("/>")
             }
         case let .text(value):
+            if !didVisitTrim {
+                target.write("\n")
+                target.write(String(repeating: "\t", count: depth))
+            }
+
+            target.write(value.addingXMLEncoding())
+        case let .raw(value):
             if !didVisitTrim {
                 target.write("\n")
                 target.write(String(repeating: "\t", count: depth))

--- a/Sources/Swim/String+XML.swift
+++ b/Sources/Swim/String+XML.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension String {
+    func addingXMLEncoding() -> String {
+        withCFString { string -> NSString in
+            CFXMLCreateStringByEscapingEntities(nil, string, nil)
+        } as String
+    }
+
+    private func withCFString<Result>(_ body: (CFString) throws -> Result) rethrows -> Result {
+        try withCString { cString in
+            try body(CFStringCreateWithCString(nil, cString, CFStringBuiltInEncodings.UTF8.rawValue))
+        }
+    }
+}

--- a/Sources/Swim/Visitor.swift
+++ b/Sources/Swim/Visitor.swift
@@ -6,6 +6,8 @@ public protocol Visitor {
     func visitElement(name: String, attributes: [String: String], child: Node?) -> Result
 
     func visitText(text: String) -> Result
+    
+    func visitRaw(raw: String) -> Result
 
     func visitComment(text: String) -> Result
 
@@ -25,6 +27,8 @@ extension Visitor {
             return visitElement(name: name, attributes: attributes, child: child)
         case .text(let text):
             return visitText(text: text)
+        case .raw(let contents):
+            return visitRaw(raw: contents)
         case .comment(let text):
             return visitComment(text: text)
         case .documentType(let name):
@@ -52,6 +56,10 @@ public extension Visitor where Result == Node {
 
     func visitDocumentType(name: String) -> Result {
         .documentType(name)
+    }
+
+    func visitRaw(raw: String) -> Result {
+        .raw(raw)
     }
 
     func visitFragment(children: [Node]) -> Result {

--- a/Tests/HTMLTests/HTMLTests.swift
+++ b/Tests/HTMLTests/HTMLTests.swift
@@ -196,6 +196,10 @@ final class HTMLTests: XCTestCase {
             func visitText(text: String) -> [String] {
                 [ text ]
             }
+            
+            func visitRaw(raw: String) -> [String] {
+                []
+            }
 
             func visitComment(text: String) -> [String] {
                 []

--- a/Tests/SwimTests/SwimTests.swift
+++ b/Tests/SwimTests/SwimTests.swift
@@ -3,5 +3,17 @@ import XCTest
 @testable import Swim
 
 final class SwimTests: XCTestCase {
+    func testText() {
+        let n: Node = "3 > 1"
+        var result = ""
+        n.write(to: &result)
+        XCTAssertEqual(result, "\n3 &gt; 1")
+    }
     
+    func testRaw() {
+        let n: Node = Node.raw("<marquee>Hello</marquee>")
+        var result = ""
+        n.write(to: &result)
+        XCTAssertEqual(result, "\n<marquee>Hello</marquee>")
+    }
 }


### PR DESCRIPTION
This PR adds support for raw nodes (they get rendered as-is, without escaping their contents). This PR also changes the behaviour of text nodes, they now get escaped. I added some very basic tests for this.

The string escaping is taken from here: https://github.com/robb/robb.swift/blob/main/Sources/robb.swift/Extensions/String+XML.swift