### PR TITLE
Quoted attributes

### DIFF
--- a/Sources/Swim/Node.swift
+++ b/Sources/Swim/Node.swift
@@ -56,7 +56,7 @@ extension Node: TextOutputStreamable {
                 guard value != "" else { continue }
 
                 target.write("=\"")
-                target.write(value)
+                target.write(value.replacingOccurrences(of: "\"", with: "&quot;"))
                 target.write("\"")
             }
 

--- a/Tests/SwimTests/SwimTests.swift
+++ b/Tests/SwimTests/SwimTests.swift
@@ -2,18 +2,29 @@ import XCTest
 
 @testable import Swim
 
+extension Node {
+    var rendered: String {
+        var result = ""
+        write(to: &result)
+        return result
+    }
+}
+
 final class SwimTests: XCTestCase {
     func testText() {
         let n: Node = "3 > 1"
-        var result = ""
-        n.write(to: &result)
-        XCTAssertEqual(result, "\n3 &gt; 1")
+        XCTAssertEqual(n.rendered, "\n3 &gt; 1")
     }
     
     func testRaw() {
         let n: Node = Node.raw("<marquee>Hello</marquee>")
-        var result = ""
-        n.write(to: &result)
-        XCTAssertEqual(result, "\n<marquee>Hello</marquee>")
+        XCTAssertEqual(n.rendered, "\n<marquee>Hello</marquee>")
+    }
+    
+    func testAttributeWithQuote() {
+        let n: Node = Node.element("a", [
+            "x": "\""
+        ], nil)
+        XCTAssertEqual(n.rendered, "\n<a x=\"&quot;\"/>")
     }
 }


### PR DESCRIPTION
If there is a quote in an attribute value, we should escape it. I am 99% sure this is all that needs to happen. Even < and > are fine to use inside attribute values.