### PR TITLE
Linux Support

### DIFF
--- a/Sources/Swim/String+XML.swift
+++ b/Sources/Swim/String+XML.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 extension String {
+    #if os(Linux)
+    func addingXMLEncoding() -> String {
+        var result = ""
+        result.reserveCapacity(count)
+        return unicodeScalars.reduce(into: result, { $0.append($1.escapingIfNeeded) })
+    }
+    #else
     func addingXMLEncoding() -> String {
         withCFString { string -> NSString in
             CFXMLCreateStringByEscapingEntities(nil, string, nil)
@@ -11,5 +18,23 @@ extension String {
         try withCString { cString in
             try body(CFStringCreateWithCString(nil, cString, CFStringBuiltInEncodings.UTF8.rawValue))
         }
+    }
+    #endif
+}
+
+extension UnicodeScalar {
+    public var htmlEscaped: String {
+        return "&#\(value);"
+    }
+    
+    /// Escapes the scalar only if it needs to be escaped for Unicode pages.
+    ///
+    /// [Reference](http://wonko.com/post/html-escaping)
+    fileprivate var escapingIfNeeded: String {
+        switch value {
+        case 33, 34, 36, 37, 38, 39, 43, 44, 60, 61, 62, 64, 91, 93, 96, 123, 125: return htmlEscaped
+        default: return String(self)
+        }
+        
     }
 }

--- a/Sources/Swim/String+XML.swift
+++ b/Sources/Swim/String+XML.swift
@@ -1,40 +1,28 @@
 import Foundation
 
 extension String {
-    #if os(Linux)
     func addingXMLEncoding() -> String {
         var result = ""
         result.reserveCapacity(count)
-        return unicodeScalars.reduce(into: result, { $0.append($1.escapingIfNeeded) })
+        return unicodeScalars.reduce(into: result, { $0.append($1.named_escapingIfNeeded) })
     }
-    #else
-    func addingXMLEncoding() -> String {
-        withCFString { string -> NSString in
-            CFXMLCreateStringByEscapingEntities(nil, string, nil)
-        } as String
-    }
-
-    private func withCFString<Result>(_ body: (CFString) throws -> Result) rethrows -> Result {
-        try withCString { cString in
-            try body(CFStringCreateWithCString(nil, cString, CFStringBuiltInEncodings.UTF8.rawValue))
-        }
-    }
-    #endif
 }
 
 extension UnicodeScalar {
-    public var htmlEscaped: String {
-        return "&#\(value);"
-    }
-    
-    /// Escapes the scalar only if it needs to be escaped for Unicode pages.
-    ///
-    /// [Reference](http://wonko.com/post/html-escaping)
-    fileprivate var escapingIfNeeded: String {
+    fileprivate var named_escapingIfNeeded: String {
         switch value {
-        case 33, 34, 36, 37, 38, 39, 43, 44, 60, 61, 62, 64, 91, 93, 96, 123, 125: return htmlEscaped
-        default: return String(self)
+        case ("&" as Unicode.Scalar).value:
+            return "&amp;"
+        case ("<" as Unicode.Scalar).value:
+            return "&lt;"
+        case (">" as Unicode.Scalar).value:
+            return "&gt;"
+        case ("\'" as Unicode.Scalar).value:
+            return "&apos;"
+        case ("\"" as Unicode.Scalar).value:
+            return "&quot;"
+        default:
+            return String(self)
         }
-        
     }
 }

--- a/Tests/SwimTests/SwimTests.swift
+++ b/Tests/SwimTests/SwimTests.swift
@@ -10,6 +10,13 @@ final class SwimTests: XCTestCase {
         XCTAssertEqual(result, "\n3 &gt; 1")
     }
     
+    func testUnicodeAndEscaping() {
+        let n: Node = "500 €"
+        var result = ""
+        n.write(to: &result)
+        XCTAssertEqual(result, "\n500 €")
+    }
+    
     func testRaw() {
         let n: Node = Node.raw("<marquee>Hello</marquee>")
         var result = ""


### PR DESCRIPTION
It seems that `CFXMLCreateStringByEscapingEntities` is not available under Linux. (Or maybe I'm wrong, that would simplify things).

This PR works around that by adding quotes manually. I haven't tested the performance, but I think this will be slower than the built-in escaping, so I only enabled it for Linux. This might give different output depending on the system. 

We use the same algorithm for our HTML library in the Swift Talk backend, and it has served us well so far. 

To test this locally on my M1 I have the following script (modified from [here](https://oleb.net/2020/swift-docker-linux/)):

```bash
#!/bin/bash
docker run --rm --privileged --interactive --tty \
                                  --security-opt seccomp=unconfined \
				  --volume "$(pwd):/src" \
                                  --workdir "/src" \
                                  swiftarm/swift
```

When you run that you get a console into which you can type `swift test` and verify that all tests pass on Linux.

Once/if this is merged in, we could also enable GitHub actions.