### PR TITLE
Scan String before escaping

### DIFF
--- a/Sources/Swim/String+XML.swift
+++ b/Sources/Swim/String+XML.swift
@@ -2,14 +2,29 @@ import Foundation
 
 extension String {
     func addingXMLEncoding() -> String {
+        guard unicodeScalars.contains(where: \.needsEscaping) else {
+            return self
+        }
+
         var result = ""
         result.reserveCapacity(count)
-        return unicodeScalars.reduce(into: result, { $0.append($1.named_escapingIfNeeded) })
+        return unicodeScalars.reduce(into: result, { $0.append($1.escapingIfNeeded) })
     }
 }
 
 extension UnicodeScalar {
-    fileprivate var named_escapingIfNeeded: String {
+    fileprivate var needsEscaping: Bool {
+        switch value {
+        case ("&" as Unicode.Scalar).value, ("<" as Unicode.Scalar).value,
+             (">" as Unicode.Scalar).value, ("\'" as Unicode.Scalar).value,
+             ("\"" as Unicode.Scalar).value:
+            return true
+        default:
+            return false
+        }
+    }
+
+    fileprivate var escapingIfNeeded: String {
         switch value {
         case ("&" as Unicode.Scalar).value:
             return "&amp;"


### PR DESCRIPTION
This adds the same approach that CF uses by scanning the String for offending characters first before committing to an allocation.

Before (`209e8a9`):

```
name               time          std        iterations
------------------------------------------------------
Build a basic page 128375.000 ns ±   3.61 %       9928
```

After:

```
name               time          std        iterations
------------------------------------------------------
Build a basic page 102250.000 ns ±   1.52 %      12034
```